### PR TITLE
Fix expressions in stored procedures

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -16,7 +16,7 @@ class Builder extends QueryBuilder
     public function fromProcedure(string $procedure, array $values = [])
     {
         $compiledProcedure = $this->grammar->compileProcedure($this, $procedure, $values);
-        
+
         // Remove any expressions from the values array, as they will have
         // already been evaluated by the grammar's parameterize() function.
         $values = array_filter($values, function ($value) {

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -16,6 +16,12 @@ class Builder extends QueryBuilder
     public function fromProcedure(string $procedure, array $values = [])
     {
         $compiledProcedure = $this->grammar->compileProcedure($this, $procedure, $values);
+        
+        // Remove any expressions from the values array, as they will have
+        // already been evaluated by the grammar's parameterize() function.
+        $values = array_filter($values, function ($value) {
+            return ! $this->grammar->isExpression($value);
+        });
 
         $this->fromRaw($compiledProcedure, array_values($values));
 


### PR DESCRIPTION
This PR fixes expressions not working in stored procedures, as they will have already been evaluated by the `parameterize()` function, causing an offset error when later passed to the queries bindings.