### PR TITLE
fix(connection): extract correct Firebird server version from remote server info

### DIFF
--- a/src/FirebirdConnection.php
+++ b/src/FirebirdConnection.php
@@ -30,7 +30,7 @@ class FirebirdConnection extends DatabaseConnection
     {
         $version = $this->getPdo()->getAttribute(PDO::ATTR_SERVER_VERSION);
 
-        return Str::match('/(?<=LI-V)\d+\.\d+\.\d+/', $version);
+        return Str::match('/\(remote server\), version "\w+-V(\d+\.\d+\.\d+)/', $version);
     }
 
     /**


### PR DESCRIPTION
Previously, the FirebirdConnection::getServerVersion() method used a regex pattern that captured the first version token found in the PDO::ATTR_SERVER_VERSION string, which could represent the client (remote interface) or access method version instead of the actual remote server version.

This update changes the extraction logic to explicitly target the "(remote server)" section of the version string, ensuring the method returns the true Firebird Server version running on the remote host.

Additionally, the regex was made more generic using `\w+-V` to ensure compatibility.

Example:
Before → "4.0.5" (from remote interface)
After  → "2.5.9" (from remote server)

Firebird/Windows/AMD/Intel/x64 (access method), version "WI-V2.5.9.27139 Firebird 2.5" Firebird/Windows/AMD/Intel/x64 (remote server), version "WI-V2.5.9.27139 Firebird 2.5/tcp (DESKTOP-BTTQQFJ)/P12" Firebird/Linux/AMD/Intel/x64 (remote interface), version "LI-V4.0.5.3140 Firebird 4.0/tcp (d532ac24d314)/P12" on disk structure version 11.2